### PR TITLE
Update the import paths for Caddy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ The options of the `login` directive are not final either: it will probably evol
 
 ## Installation
 
-The simplest way is to follow [the Caddy documentation](https://github.com/mholt/caddy#build) to build your binary.
+The simplest way is to follow [the Caddy documentation](https://github.com/caddyserver/caddy#build) to build your binary.
 
 Then you just need to import the plugin:
 
     package main
 
     import (
-            "github.com/mholt/caddy/caddy/caddymain"
+            "github.com/caddyserver/caddy/caddy/caddymain"
 
             _ "go.rischmann.fr/caddy-login-oauth2"
     )

--- a/handler.go
+++ b/handler.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"go.rischmann.fr/caddy-login-oauth2/internal"
 	"golang.org/x/oauth2"
 	profileapi "google.golang.org/api/oauth2/v2"

--- a/setup.go
+++ b/setup.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	"golang.org/x/oauth2/google"
 )
 


### PR DESCRIPTION
This pull request makes caddy-login-oauth2 compatible with Caddy v1.0.1+ (see epicagency/caddy-expires#6 for reference) by updating the import paths for Caddy.